### PR TITLE
fix: missing include for std::function

### DIFF
--- a/src/logging_system.cpp
+++ b/src/logging_system.cpp
@@ -6,6 +6,7 @@
 #include <soralog/logging_system.hpp>
 
 #include <cassert>
+#include <functional>
 #include <iostream>
 #include <set>
 


### PR DESCRIPTION
Build error with gcc (GCC) 12.1.1 20220507 (Red Hat 12.1.1-1)
Missing include functional
```
soralog/src/logging_system.cpp: In member function ‘void soralog::LoggingSystem::setParentOfGroup(const std::shared_ptr<soralog::Group>&, const std::shared_ptr<soralog::Group>&)’:
soralog/src/logging_system.cpp:173:10: error: ‘function’ is not a member of ‘std’
  173 |     std::function<int(const std::shared_ptr<const Group> &)> fn =
      |          ^~~~~~~~
soralog/src/logging_system.cpp:15:1: note: ‘std::function’ is defined in header ‘<functional>’; did you forget to ‘#include <functional>’?
   14 | #include <soralog/logger.hpp>
  +++ |+#include <functional>
   15 | 
```